### PR TITLE
Fix #135 Remove deprecation warnings

### DIFF
--- a/modules/accumulo/src/main/java/org/apache/fluo/recipes/accumulo/export/AccumuloExporter.java
+++ b/modules/accumulo/src/main/java/org/apache/fluo/recipes/accumulo/export/AccumuloExporter.java
@@ -25,8 +25,6 @@ import org.apache.fluo.api.config.SimpleConfiguration;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.RowColumn;
 import org.apache.fluo.recipes.accumulo.export.function.AccumuloTranslator;
-import org.apache.fluo.recipes.core.export.ExportQueue.Options;
-import org.apache.fluo.recipes.core.export.Exporter;
 import org.apache.fluo.recipes.core.export.SequencedExport;
 
 /**
@@ -39,11 +37,13 @@ import org.apache.fluo.recipes.core.export.SequencedExport;
  *             {@link AccumuloTranslator}
  */
 @Deprecated
-public abstract class AccumuloExporter<K, V> extends Exporter<K, V> {
+public abstract class AccumuloExporter<K, V> extends
+    org.apache.fluo.recipes.core.export.Exporter<K, V> {
 
   /**
    * Use this to configure the Accumulo table where an AccumuloExporter's mutations will be written.
-   * Create and pass to {@link Options#setExporterConfiguration(SimpleConfiguration)}
+   * Create and pass to
+   * {@link org.apache.fluo.recipes.core.export.ExportQueue.Options#setExporterConfiguration(SimpleConfiguration)}
    *
    * @since 1.0.0
    */
@@ -64,7 +64,7 @@ public abstract class AccumuloExporter<K, V> extends Exporter<K, V> {
   private org.apache.fluo.recipes.accumulo.export.function.AccumuloExporter<K, V> accumuloWriter;
 
   @Override
-  public void init(Exporter.Context context) throws Exception {
+  public void init(org.apache.fluo.recipes.core.export.Exporter.Context context) throws Exception {
     SimpleConfiguration sc = context.getExporterConfiguration();
     String instanceName = sc.getString("instanceName");
     String zookeepers = sc.getString("zookeepers");

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/export/ExportObserver.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/export/ExportObserver.java
@@ -19,7 +19,6 @@ import org.apache.fluo.api.client.TransactionBase;
 import org.apache.fluo.api.config.SimpleConfiguration;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
-import org.apache.fluo.api.observer.AbstractObserver;
 import org.apache.fluo.recipes.core.serialization.SimpleSerializer;
 
 /**
@@ -27,7 +26,7 @@ import org.apache.fluo.recipes.core.serialization.SimpleSerializer;
  * @deprecated since 1.1.0
  */
 @Deprecated
-public class ExportObserver<K, V> extends AbstractObserver {
+public class ExportObserver<K, V> extends org.apache.fluo.api.observer.AbstractObserver {
 
   private ExportObserverImpl<K, V> eoi;
 
@@ -70,7 +69,6 @@ public class ExportObserver<K, V> extends AbstractObserver {
         return context;
       }
     });
-
 
     this.eoi =
         new ExportObserverImpl<K, V>(queueId, opts.fluentCfg, serializer, exporter::processExports);

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/export/ExportQueue.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/export/ExportQueue.java
@@ -28,7 +28,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.hash.Hashing;
 import org.apache.fluo.api.client.TransactionBase;
 import org.apache.fluo.api.config.FluoConfiguration;
-import org.apache.fluo.api.config.ObserverSpecification;
 import org.apache.fluo.api.config.SimpleConfiguration;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.observer.Observer;
@@ -105,7 +104,7 @@ public class ExportQueue<K, V> {
 
   /**
    * Part of a fluent API for configuring a export queue.
-   * 
+   *
    * @since 1.1.0
    */
   public static interface FluentArg1 {
@@ -116,7 +115,7 @@ public class ExportQueue<K, V> {
 
   /**
    * Part of a fluent API for configuring a export queue.
-   * 
+   *
    * @since 1.1.0
    */
   public static interface FluentArg2 {
@@ -127,7 +126,7 @@ public class ExportQueue<K, V> {
 
   /**
    * Part of a fluent API for configuring a export queue.
-   * 
+   *
    * @since 1.1.0
    */
   public static interface FluentArg3 {
@@ -136,7 +135,7 @@ public class ExportQueue<K, V> {
 
   /**
    * Part of a fluent API for configuring a export queue.
-   * 
+   *
    * @since 1.1.0
    */
   public static interface FluentOptions {
@@ -191,8 +190,9 @@ public class ExportQueue<K, V> {
     SimpleConfiguration appConfig = fluoConfig.getAppConfiguration();
     opts.save(appConfig);
 
-    fluoConfig.addObserver(new ObserverSpecification(ExportObserver.class.getName(), Collections
-        .singletonMap("queueId", opts.fluentCfg.queueId)));
+    fluoConfig
+        .addObserver(new org.apache.fluo.api.config.ObserverSpecification(ExportObserver.class
+            .getName(), Collections.singletonMap("queueId", opts.fluentCfg.queueId)));
   }
 
   /**
@@ -241,7 +241,7 @@ public class ExportQueue<K, V> {
   /**
    * Registers an observer that will export queued data. Use this method in conjunction with
    * {@link ExportQueue#configure(String)}.
-   * 
+   *
    * @since 1.1.0
    */
   public void registerObserver(ObserverProvider.Registry obsRegistry,
@@ -265,6 +265,7 @@ public class ExportQueue<K, V> {
    * @since 1.0.0
    * @deprecated since 1.1.0 use {@link ExportQueue#configure(String)}
    */
+  @Deprecated
   public static class Options {
 
     private static final String PREFIX = FluentConfigurator.PREFIX;

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/map/CollisionFreeMap.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/map/CollisionFreeMap.java
@@ -28,7 +28,6 @@ import com.google.common.hash.Hashing;
 import org.apache.fluo.api.client.SnapshotBase;
 import org.apache.fluo.api.client.TransactionBase;
 import org.apache.fluo.api.config.FluoConfiguration;
-import org.apache.fluo.api.config.ObserverSpecification;
 import org.apache.fluo.api.config.SimpleConfiguration;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Bytes.BytesBuilder;
@@ -50,6 +49,7 @@ import org.apache.fluo.recipes.core.serialization.SimpleSerializer;
  * @since 1.0.0
  * @deprecated since 1.1.0 use {@link CombineQueue}
  */
+@Deprecated
 public class CollisionFreeMap<K, V> {
 
   private Bytes updatePrefix;
@@ -391,8 +391,8 @@ public class CollisionFreeMap<K, V> {
 
     opts.save(fluoConfig.getAppConfiguration());
 
-    fluoConfig.addObserver(new ObserverSpecification(CollisionFreeMapObserver.class.getName(),
-        ImmutableMap.of("mapId", opts.mapId)));
+    fluoConfig.addObserver(new org.apache.fluo.api.config.ObserverSpecification(
+        CollisionFreeMapObserver.class.getName(), ImmutableMap.of("mapId", opts.mapId)));
   }
 
   /**

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/map/CollisionFreeMapObserver.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/map/CollisionFreeMapObserver.java
@@ -18,7 +18,6 @@ package org.apache.fluo.recipes.core.map;
 import org.apache.fluo.api.client.TransactionBase;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
-import org.apache.fluo.api.observer.AbstractObserver;
 
 /**
  * This class is configured for use by CollisionFreeMap.configure(FluoConfiguration,
@@ -28,7 +27,7 @@ import org.apache.fluo.api.observer.AbstractObserver;
  * @deprecated since 1.1.0
  */
 @Deprecated
-public class CollisionFreeMapObserver extends AbstractObserver {
+public class CollisionFreeMapObserver extends org.apache.fluo.api.observer.AbstractObserver {
 
   @SuppressWarnings("rawtypes")
   private CollisionFreeMap cfm;

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/map/Combiner.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/map/Combiner.java
@@ -25,6 +25,7 @@ import org.apache.fluo.recipes.core.combine.CombineQueue;
  * @deprecated since 1.1.0 use {@link org.apache.fluo.recipes.core.combine.Combiner} and
  *             {@link CombineQueue}
  */
+@Deprecated
 public interface Combiner<K, V> {
 
   /**

--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/map/UpdateObserver.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/map/UpdateObserver.java
@@ -18,7 +18,6 @@ package org.apache.fluo.recipes.core.map;
 import java.util.Iterator;
 
 import org.apache.fluo.api.client.TransactionBase;
-import org.apache.fluo.api.observer.Observer.Context;
 import org.apache.fluo.recipes.core.combine.ChangeObserver;
 import org.apache.fluo.recipes.core.combine.CombineQueue;
 
@@ -32,7 +31,8 @@ import org.apache.fluo.recipes.core.combine.CombineQueue;
 @Deprecated
 public abstract class UpdateObserver<K, V> {
 
-  public void init(String mapId, Context observerContext) throws Exception {}
+  public void init(String mapId, org.apache.fluo.api.observer.Observer.Context observerContext)
+      throws Exception {}
 
   public abstract void updatingValues(TransactionBase tx, Iterator<Update<K, V>> updates);
 }

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/export/OptionsTest.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/export/OptionsTest.java
@@ -18,9 +18,7 @@ package org.apache.fluo.recipes.core.export;
 import java.util.List;
 
 import org.apache.fluo.api.config.FluoConfiguration;
-import org.apache.fluo.api.config.ObserverSpecification;
 import org.apache.fluo.api.config.SimpleConfiguration;
-import org.apache.fluo.recipes.core.export.ExportQueue.Options;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,11 +32,15 @@ public class OptionsTest {
     ec1.setProperty("ep1", "ev1");
     ec1.setProperty("ep2", 3L);
 
-    ExportQueue.configure(conf, new Options("Q1", "ET", "KT", "VT", 100));
-    ExportQueue.configure(conf, new Options("Q2", "ET2", "KT2", "VT2", 200).setBucketsPerTablet(20)
-        .setBufferSize(1000000).setExporterConfiguration(ec1));
+    ExportQueue.configure(conf, new org.apache.fluo.recipes.core.export.ExportQueue.Options("Q1",
+        "ET", "KT", "VT", 100));
+    ExportQueue.configure(conf, new org.apache.fluo.recipes.core.export.ExportQueue.Options("Q2",
+        "ET2", "KT2", "VT2", 200).setBucketsPerTablet(20).setBufferSize(1000000)
+        .setExporterConfiguration(ec1));
 
-    Options opts1 = new Options("Q1", conf.getAppConfiguration());
+    org.apache.fluo.recipes.core.export.ExportQueue.Options opts1 =
+        new org.apache.fluo.recipes.core.export.ExportQueue.Options("Q1",
+            conf.getAppConfiguration());
 
     Assert.assertEquals(opts1.fluentCfg.exporterType, "ET");
     Assert.assertEquals(opts1.fluentCfg.keyType, "KT");
@@ -49,7 +51,9 @@ public class OptionsTest {
     Assert.assertEquals(opts1.fluentCfg.bufferSize.intValue(),
         FluentConfigurator.DEFAULT_BUFFER_SIZE);
 
-    Options opts2 = new Options("Q2", conf.getAppConfiguration());
+    org.apache.fluo.recipes.core.export.ExportQueue.Options opts2 =
+        new org.apache.fluo.recipes.core.export.ExportQueue.Options("Q2",
+            conf.getAppConfiguration());
 
     Assert.assertEquals(opts2.fluentCfg.exporterType, "ET2");
     Assert.assertEquals(opts2.fluentCfg.keyType, "KT2");
@@ -63,9 +67,10 @@ public class OptionsTest {
     Assert.assertEquals("ev1", ec2.getString("ep1"));
     Assert.assertEquals(3, ec2.getInt("ep2"));
 
-    List<ObserverSpecification> obsSpecs = conf.getObserverSpecifications();
+    List<org.apache.fluo.api.config.ObserverSpecification> obsSpecs =
+        conf.getObserverSpecifications();
     Assert.assertTrue(obsSpecs.size() == 2);
-    for (ObserverSpecification ospec : obsSpecs) {
+    for (org.apache.fluo.api.config.ObserverSpecification ospec : obsSpecs) {
       Assert.assertEquals(ExportObserver.class.getName(), ospec.getClassName());
       String qid = ospec.getConfiguration().getString("queueId");
       Assert.assertTrue(qid.equals("Q1") || qid.equals("Q2"));

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/OptionsTest.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/OptionsTest.java
@@ -16,7 +16,6 @@
 package org.apache.fluo.recipes.core.map;
 
 import org.apache.fluo.api.config.FluoConfiguration;
-import org.apache.fluo.recipes.core.map.CollisionFreeMap.Options;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,20 +25,27 @@ public class OptionsTest {
   public void testExportQueueOptions() {
     FluoConfiguration conf = new FluoConfiguration();
 
-    CollisionFreeMap.configure(conf, new Options("Q1", "CT", "KT", "VT", 100));
-    CollisionFreeMap.configure(conf, new Options("Q2", "CT2", "KT2", "VT2", 200)
-        .setBucketsPerTablet(20).setBufferSize(1000000));
+    CollisionFreeMap.configure(conf, new org.apache.fluo.recipes.core.map.CollisionFreeMap.Options(
+        "Q1", "CT", "KT", "VT", 100));
+    CollisionFreeMap.configure(conf, new org.apache.fluo.recipes.core.map.CollisionFreeMap.Options(
+        "Q2", "CT2", "KT2", "VT2", 200).setBucketsPerTablet(20).setBufferSize(1000000));
 
-    Options opts1 = new Options("Q1", conf.getAppConfiguration());
+    org.apache.fluo.recipes.core.map.CollisionFreeMap.Options opts1 =
+        new org.apache.fluo.recipes.core.map.CollisionFreeMap.Options("Q1",
+            conf.getAppConfiguration());
 
     Assert.assertEquals(opts1.combinerType, "CT");
     Assert.assertEquals(opts1.keyType, "KT");
     Assert.assertEquals(opts1.valueType, "VT");
     Assert.assertEquals(opts1.numBuckets, 100);
-    Assert.assertEquals(opts1.bucketsPerTablet.intValue(), Options.DEFAULT_BUCKETS_PER_TABLET);
-    Assert.assertEquals(opts1.bufferSize.intValue(), Options.DEFAULT_BUFFER_SIZE);
+    Assert.assertEquals(opts1.bucketsPerTablet.intValue(),
+        org.apache.fluo.recipes.core.map.CollisionFreeMap.Options.DEFAULT_BUCKETS_PER_TABLET);
+    Assert.assertEquals(opts1.bufferSize.intValue(),
+        org.apache.fluo.recipes.core.map.CollisionFreeMap.Options.DEFAULT_BUFFER_SIZE);
 
-    Options opts2 = new Options("Q2", conf.getAppConfiguration());
+    org.apache.fluo.recipes.core.map.CollisionFreeMap.Options opts2 =
+        new org.apache.fluo.recipes.core.map.CollisionFreeMap.Options("Q2",
+            conf.getAppConfiguration());
 
     Assert.assertEquals(opts2.combinerType, "CT2");
     Assert.assertEquals(opts2.keyType, "KT2");

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/SplitsTest.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/SplitsTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.recipes.core.common.TableOptimizations;
-import org.apache.fluo.recipes.core.map.CollisionFreeMap.Options;
 import org.apache.fluo.recipes.core.map.it.WordCountCombiner;
 import org.junit.Assert;
 import org.junit.Test;
@@ -40,7 +39,9 @@ public class SplitsTest {
   @Test
   public void testSplits() {
 
-    Options opts = new Options("foo", WordCountCombiner.class, String.class, Long.class, 3);
+    org.apache.fluo.recipes.core.map.CollisionFreeMap.Options opts =
+        new org.apache.fluo.recipes.core.map.CollisionFreeMap.Options("foo",
+            WordCountCombiner.class, String.class, Long.class, 3);
     opts.setBucketsPerTablet(1);
     FluoConfiguration fluoConfig = new FluoConfiguration();
     CollisionFreeMap.configure(fluoConfig, opts);
@@ -55,7 +56,9 @@ public class SplitsTest {
 
     Assert.assertEquals(expected1, sort(tableOptim1.getSplits()));
 
-    Options opts2 = new Options("bar", WordCountCombiner.class, String.class, Long.class, 6);
+    org.apache.fluo.recipes.core.map.CollisionFreeMap.Options opts2 =
+        new org.apache.fluo.recipes.core.map.CollisionFreeMap.Options("bar",
+            WordCountCombiner.class, String.class, Long.class, 6);
     opts2.setBucketsPerTablet(2);
     CollisionFreeMap.configure(fluoConfig, opts2);
 

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/CollisionFreeMapIT.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/CollisionFreeMapIT.java
@@ -29,12 +29,10 @@ import org.apache.fluo.api.client.Snapshot;
 import org.apache.fluo.api.client.Transaction;
 import org.apache.fluo.api.client.scanner.CellScanner;
 import org.apache.fluo.api.config.FluoConfiguration;
-import org.apache.fluo.api.config.ObserverSpecification;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.api.data.RowColumnValue;
 import org.apache.fluo.api.data.Span;
 import org.apache.fluo.api.mini.MiniFluo;
-import org.apache.fluo.recipes.core.map.CollisionFreeMap;
 import org.apache.fluo.recipes.core.serialization.SimpleSerializer;
 import org.junit.After;
 import org.junit.Assert;
@@ -47,7 +45,7 @@ public class CollisionFreeMapIT {
 
   private MiniFluo miniFluo;
 
-  private CollisionFreeMap<String, Long> wcMap;
+  private org.apache.fluo.recipes.core.map.CollisionFreeMap<String, Long> wcMap;
 
   static final String MAP_ID = "wcm";
 
@@ -60,16 +58,20 @@ public class CollisionFreeMapIT {
     props.setWorkerThreads(20);
     props.setMiniDataDir("target/mini");
 
-    props.addObserver(new ObserverSpecification(DocumentObserver.class.getName()));
+    props.addObserver(new org.apache.fluo.api.config.ObserverSpecification(DocumentObserver.class
+        .getName()));
 
     SimpleSerializer.setSerializer(props, TestSerializer.class);
 
-    CollisionFreeMap.configure(props, new CollisionFreeMap.Options(MAP_ID, WordCountCombiner.class,
-        WordCountObserver.class, String.class, Long.class, 17));
+    org.apache.fluo.recipes.core.map.CollisionFreeMap.configure(props,
+        new org.apache.fluo.recipes.core.map.CollisionFreeMap.Options(MAP_ID,
+            WordCountCombiner.class, WordCountObserver.class, String.class, Long.class, 17));
 
     miniFluo = FluoFactory.newMiniFluo(props);
 
-    wcMap = CollisionFreeMap.getInstance(MAP_ID, props.getAppConfiguration());
+    wcMap =
+        org.apache.fluo.recipes.core.map.CollisionFreeMap.getInstance(MAP_ID,
+            props.getAppConfiguration());
   }
 
   @After
@@ -104,7 +106,6 @@ public class CollisionFreeMapIT {
     Map<String, Long> counts = new HashMap<>();
 
     try (Snapshot snap = fc.newSnapshot()) {
-
 
       CellScanner scanner =
           snap.scanner().over(Span.prefix("d:")).fetch(new Column("content", "current")).build();

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/DocumentObserver.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/DocumentObserver.java
@@ -22,7 +22,6 @@ import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
-import org.apache.fluo.recipes.core.map.CollisionFreeMap;
 import org.apache.fluo.recipes.core.types.TypedObserver;
 import org.apache.fluo.recipes.core.types.TypedTransactionBase;
 
@@ -30,11 +29,13 @@ import org.apache.fluo.recipes.core.types.TypedTransactionBase;
 // TODO move to CombineQueue test when removing CFM
 public class DocumentObserver extends TypedObserver {
 
-  CollisionFreeMap<String, Long> wcm;
+  org.apache.fluo.recipes.core.map.CollisionFreeMap<String, Long> wcm;
 
   @Override
   public void init(Context context) throws Exception {
-    wcm = CollisionFreeMap.getInstance(CollisionFreeMapIT.MAP_ID, context.getAppConfiguration());
+    wcm =
+        org.apache.fluo.recipes.core.map.CollisionFreeMap.getInstance(CollisionFreeMapIT.MAP_ID,
+            context.getAppConfiguration());
   }
 
   @Override

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/WordCountCombiner.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/WordCountCombiner.java
@@ -18,11 +18,9 @@ package org.apache.fluo.recipes.core.map.it;
 import java.util.Iterator;
 import java.util.Optional;
 
-import org.apache.fluo.recipes.core.map.Combiner;
-
 @Deprecated
 // TODO move to CombineQueue test when removing CFM
-public class WordCountCombiner implements Combiner<String, Long> {
+public class WordCountCombiner implements org.apache.fluo.recipes.core.map.Combiner<String, Long> {
   @Override
   public Optional<Long> combine(String key, Iterator<Long> updates) {
     long sum = 0;

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/WordCountObserver.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/WordCountObserver.java
@@ -21,18 +21,18 @@ import java.util.Optional;
 import org.apache.fluo.api.client.TransactionBase;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
-import org.apache.fluo.recipes.core.map.Update;
-import org.apache.fluo.recipes.core.map.UpdateObserver;
 
 @Deprecated
 // TODO move to CombineQueue test when removing CFM
-public class WordCountObserver extends UpdateObserver<String, Long> {
+public class WordCountObserver extends
+    org.apache.fluo.recipes.core.map.UpdateObserver<String, Long> {
 
   @Override
-  public void updatingValues(TransactionBase tx, Iterator<Update<String, Long>> updates) {
+  public void updatingValues(TransactionBase tx,
+      Iterator<org.apache.fluo.recipes.core.map.Update<String, Long>> updates) {
 
     while (updates.hasNext()) {
-      Update<String, Long> update = updates.next();
+      org.apache.fluo.recipes.core.map.Update<String, Long> update = updates.next();
 
       Optional<Long> oldVal = update.getOldValue();
       Optional<Long> newVal = update.getNewValue();


### PR DESCRIPTION
Add missing @Deprecation annotations
Avoid warning-triggering imports of deprecated classes

This cleans up the warnings in the build so that new warnings which may need to be triage'd won't be lost in the noise. It's not pretty to inline the imports and use the fully-qualified class names, but it's only for classes already deprecated, and I think reducing the noise so we can more easily identify new items for triage outweighs this ugliness.