### PR TITLE
Build against Fluo 1.2.0 and Accumulo 1.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,30 @@
 # copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance with the License. You may obtain a
 # copy of the License at
-#  
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed under the License
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
-
 language: java
-jdk:
-  - oraclejdk8
-env:
-  - ACCUMULO_VERSION_OPT=
-  - ACCUMULO_VERSION_OPT=-Daccumulo.version=1.8.1
-install: echo Skipping pre-fetch of Maven dependencies via early build
-before_script:
-  - unset _JAVA_OPTIONS
-script:
-  - mvn -U clean verify javadoc:jar $ACCUMULO_VERSION_OPT
+notifications:
+  irc:
+    channels:
+      - "chat.freenode.net#fluo"
+    use_notice: true
+    on_success: change
+    on_failure: always
+    skip_join: true
 cache:
   directories:
     - $HOME/.m2
+install: echo NOOP Skipping pre-fetch of Maven dependencies
+jdk:
+  - openjdk8
+env:
+  - ADDITIONAL_MAVEN_OPTS=
+  - ADDITIONAL_MAVEN_OPTS=-Daccumulo.version=1.8.1
+script:
+  - mvn clean verify javadoc:jar $ADDITIONAL_MAVEN_OPTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ cache:
 install: echo NOOP Skipping pre-fetch of Maven dependencies
 jdk:
   - openjdk8
+before_script:
+  - unset _JAVA_OPTIONS
 env:
   - ADDITIONAL_MAVEN_OPTS=
   - ADDITIONAL_MAVEN_OPTS=-Daccumulo.version=1.8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ language: java
 jdk:
   - oraclejdk8
 env:
-  - EXTRA_OPTS=
-  - EXTRA_OPTS=-Daccumulo.version=1.8.1
+  - ACCUMULO_VERSION_OPT=
+  - ACCUMULO_VERSION_OPT=-Daccumulo.version=1.8.1
 script:
-  - mvn -U clean verify javadoc:jar $EXTRA_OPTS
+  - mvn -U clean verify javadoc:jar $ACCUMULO_VERSION_OPT
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ jdk:
 env:
   - ACCUMULO_VERSION_OPT=
   - ACCUMULO_VERSION_OPT=-Daccumulo.version=1.8.1
+install: echo Skipping pre-fetch of Maven dependencies via early build
 before_script:
-  - _JAVA_OPTIONS=
+  - unset _JAVA_OPTIONS
 script:
   - mvn -U clean verify javadoc:jar $ACCUMULO_VERSION_OPT
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ jdk:
 env:
   - ACCUMULO_VERSION_OPT=
   - ACCUMULO_VERSION_OPT=-Daccumulo.version=1.8.1
+before_script:
+  - _JAVA_OPTIONS=
 script:
   - mvn -U clean verify javadoc:jar $ACCUMULO_VERSION_OPT
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@
 language: java
 jdk:
   - oraclejdk8
-script: mvn -U verify javadoc:jar
+env:
+  - EXTRA_OPTS=
+  - EXTRA_OPTS=-Daccumulo.version=1.8.1
+script:
+  - mvn -U clean verify javadoc:jar $EXTRA_OPTS
 cache:
   directories:
     - $HOME/.m2

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Fluo Recipes
-Copyright 2017 The Apache Software Foundation.
+Copyright 2018 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/pom.xml
+++ b/pom.xml
@@ -50,22 +50,15 @@
     <url>https://github.com/apache/fluo-recipes/issues</url>
   </issueManagement>
   <properties>
-    <accumulo.version>1.6.6</accumulo.version>
+    <accumulo.version>1.7.3</accumulo.version>
     <curator.version>2.7.1</curator.version>
     <findbugs.maxRank>13</findbugs.maxRank>
-    <fluo.version>1.1.0-incubating</fluo.version>
+    <fluo.version>1.2.0</fluo.version>
     <hadoop.version>2.6.3</hadoop.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <releaseProfiles>fluo-recipes-release</releaseProfiles>
     <spark.version>1.5.2</spark.version>
-    <!--
-      If attempting to build against Accumulo 1.8.X, then set the thrift version to 0.9.3.
-      Otherwise MiniAccumulo may hang. This may happen because Fluo 1.0.0 depends on thrift 0.9.1,
-      Accumulo 1.8.0 depends on Thrift 0.9.3, and Thrift made breaking changes in libthrift between
-      0.9.1 and 0.9.3.
-     -->
-    <thrift.version>0.9.1</thrift.version>
     <zookeeper.version>3.4.8</zookeeper.version>
   </properties>
   <dependencyManagement>
@@ -199,11 +192,6 @@
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_2.10</artifactId>
         <version>${spark.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.thrift</groupId>
-        <artifactId>libthrift</artifactId>
-        <version>${thrift.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
* Update build configuration to build against Fluo 1.2.0
* Change Accumulo default version to 1.7.3, since Fluo 1.2.0 requires 1.7
* Update copyright date
* Update Travis config to build with both Accumulo 1.7.3 and 1.8.1
* Remove unused thrift dependency (version need not be managed
  since Fluo 1.2.0 now shades its version, so it won't conflict with
  Accumulo's version)