### PR TITLE
Update to work with Accumulo 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,5 @@ before_script:
   - unset _JAVA_OPTIONS
 env:
   - ADDITIONAL_MAVEN_OPTS=
-  - ADDITIONAL_MAVEN_OPTS=-Daccumulo.version=1.9.2
 script:
   - mvn clean verify javadoc:jar $ADDITIONAL_MAVEN_OPTS

--- a/modules/accumulo/pom.xml
+++ b/modules/accumulo/pom.xml
@@ -25,10 +25,6 @@
   <name>Apache Fluo Recipes for Apache Accumulo</name>
   <dependencies>
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>

--- a/modules/accumulo/src/main/spotbugs/exclude-filter.xml
+++ b/modules/accumulo/src/main/spotbugs/exclude-filter.xml
@@ -1,0 +1,23 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<FindBugsFilter>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
+</FindBugsFilter>

--- a/modules/core/src/main/spotbugs/exclude-filter.xml
+++ b/modules/core/src/main/spotbugs/exclude-filter.xml
@@ -1,0 +1,23 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<FindBugsFilter>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
+</FindBugsFilter>

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/export/it/ExportTestBase.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/export/it/ExportTestBase.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/modules/spark/pom.xml
+++ b/modules/spark/pom.xml
@@ -25,10 +25,6 @@
   <name>Apache Fluo Recipes for Apache Spark</name>
   <dependencies>
     <dependency>
-      <groupId>commons-configuration</groupId>
-      <artifactId>commons-configuration</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-core</artifactId>
     </dependency>
@@ -42,18 +38,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <!-- Causes conflicts with servlet-api in Spark -->
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>hadoop-client-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
+      <artifactId>spark-core_2.12</artifactId>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
+++ b/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
@@ -48,6 +48,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import scala.Tuple2;
 
 /**
@@ -266,7 +267,7 @@ public class FluoSparkHelper {
      * @return this
      * @deprecated use {@link #setAccumuloClient(AccumuloClient)}
      */
-    @Deprecated(since = "1.2.0", forRemoval = true)
+    @Deprecated(since = "1.3.0", forRemoval = true)
     public BulkImportOptions setAccumuloConnector(Connector conn) {
       Objects.requireNonNull(conn);
       this.conn = conn;

--- a/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
+++ b/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
@@ -144,7 +144,7 @@ public class FluoSparkHelper {
       for (FluoKeyValue kv : fkvg.getKeyValues()) {
         output.add(new Tuple2<>(kv.getKey(), kv.getValue()));
       }
-      return output;
+      return output.iterator();
     });
 
     bulkImportKvToAccumulo(kvData, fluoConfig.getAccumuloTable(), opts);

--- a/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
+++ b/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
@@ -48,7 +48,6 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import scala.Tuple2;
 
 /**

--- a/modules/spark/src/main/spotbugs/exclude-filter.xml
+++ b/modules/spark/src/main/spotbugs/exclude-filter.xml
@@ -1,0 +1,23 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<FindBugsFilter>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
+</FindBugsFilter>

--- a/modules/test/src/main/java/org/apache/fluo/recipes/test/FluoITHelper.java
+++ b/modules/test/src/main/java/org/apache/fluo/recipes/test/FluoITHelper.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -24,6 +24,9 @@ import java.util.Map;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -145,7 +148,9 @@ public class FluoITHelper {
    *
    * @param conn Accumulo connector of to instance with table to print
    * @param accumuloTable Accumulo table to print
+   * @deprecated since 1.3.0 use {@link #printAccumuloTable(AccumuloClient, String)}
    */
+  @Deprecated(since = "1.3.0", forRemoval = true)
   public static void printAccumuloTable(Connector conn, String accumuloTable) {
     Scanner scanner = null;
     try {
@@ -161,6 +166,23 @@ public class FluoITHelper {
       System.out.println(entry.getKey() + " " + entry.getValue());
     }
     System.out.println("== accumulo end ==");
+  }
+
+  /**
+   * Prints specified Accumulo table
+   *
+   * @param client Accumulo clientto instance with table to print
+   * @param accumuloTable Accumulo table to print
+   *
+   * @since 1.3.0
+   */
+  @SuppressWarnings("deprecation")
+  public static void printAccumuloTable(AccumuloClient client, String accumuloTable) {
+    try {
+      printAccumuloTable(Connector.from(client), accumuloTable);
+    } catch (AccumuloSecurityException | AccumuloException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private static boolean diff(String dataType, String expected, String actual) {
@@ -187,7 +209,9 @@ public class FluoITHelper {
    * @param accumuloTable Accumulo table with actual data
    * @param expected RowColumnValue list containing expected data
    * @return True if actual data matches expected data
+   * @deprecated since 1.3.0 use {@link #verifyAccumuloTable(AccumuloClient, String, Collection)}
    */
+  @Deprecated(since = "1.3.0", forRemoval = true)
   public static boolean verifyAccumuloTable(Connector conn, String accumuloTable,
       Collection<RowColumnValue> expected) {
 
@@ -229,6 +253,26 @@ public class FluoITHelper {
 
     log.debug("Actual data matched expected data");
     return true;
+  }
+
+  /**
+   * Verifies that actual data in Accumulo table matches expected data
+   *
+   * @param client Client from Accumulo instance with actual data
+   * @param accumuloTable Accumulo table with actual data
+   * @param expected RowColumnValue list containing expected data
+   * @return True if actual data matches expected data
+   *
+   * @since 1.3.0
+   */
+  @SuppressWarnings("deprecation")
+  public static boolean verifyAccumuloTable(AccumuloClient client, String accumuloTable,
+      Collection<RowColumnValue> expected) {
+    try {
+      return verifyAccumuloTable(Connector.from(client), accumuloTable, expected);
+    } catch (AccumuloSecurityException | AccumuloException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**

--- a/modules/test/src/main/spotbugs/exclude-filter.xml
+++ b/modules/test/src/main/spotbugs/exclude-filter.xml
@@ -1,0 +1,23 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<FindBugsFilter>
+  <Match>
+    <!-- Must ignore these everywhere, because of a javac byte code generation bug -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+  </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <url>https://github.com/apache/fluo-recipes/issues</url>
   </issueManagement>
   <properties>
-    <accumulo.version>1.7.3</accumulo.version>
+    <accumulo.version>2.0.0</accumulo.version>
     <curator.version>2.7.1</curator.version>
     <findbugs.maxRank>13</findbugs.maxRank>
     <fluo.version>1.2.0</fluo.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,14 +51,15 @@
   </issueManagement>
   <properties>
     <accumulo.version>2.0.0</accumulo.version>
-    <curator.version>2.7.1</curator.version>
-    <findbugs.maxRank>13</findbugs.maxRank>
-    <fluo.version>1.2.0</fluo.version>
-    <hadoop.version>2.6.3</hadoop.version>
+    <curator.version>4.0.1</curator.version>
+    <!-- Prevent findbugs from runnning because it does not work with Java 11 and is configured to run by parent pom.  Spotbugs is configured in place of findbugs. -->
+    <findbugs.skip>true</findbugs.skip>
+    <fluo.version>2.0.0-SNAPSHOT</fluo.version>
+    <hadoop.version>3.1.0</hadoop.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <releaseProfiles>fluo-recipes-release</releaseProfiles>
-    <spark.version>1.5.2</spark.version>
+    <spark.version>2.4.6</spark.version>
     <zookeeper.version>3.4.8</zookeeper.version>
   </properties>
   <dependencyManagement>
@@ -69,6 +70,11 @@
         <version>3.0.3</version>
       </dependency>
       <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>4.0.2</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.2.4</version>
@@ -76,17 +82,12 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>13.0.1</version>
+        <version>27.0-jre</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
         <version>3.2.1</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-configuration</groupId>
-        <artifactId>commons-configuration</artifactId>
-        <version>1.10</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -185,12 +186,17 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-client</artifactId>
+        <artifactId>hadoop-client-api</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-client-runtime</artifactId>
         <version>${hadoop.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-core_2.10</artifactId>
+        <artifactId>spark-core_2.12</artifactId>
         <version>${spark.version}</version>
       </dependency>
       <dependency>
@@ -206,7 +212,7 @@
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
-        <version>2.10.4</version>
+        <version>2.12.11</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -218,6 +224,26 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>4.0.0</version>
+          <configuration>
+            <xmlOutput>true</xmlOutput>
+            <effort>Max</effort>
+            <failOnError>true</failOnError>
+            <includeTests>true</includeTests>
+            <maxRank>13</maxRank>
+            <jvmArgs>-Dcom.overstock.findbugs.ignore=com.google.common.util.concurrent.RateLimiter,com.google.common.hash.Hasher,com.google.common.hash.HashCode,com.google.common.hash.HashFunction,com.google.common.hash.Hashing,com.google.common.cache.Cache,com.google.common.io.CountingOutputStream,com.google.common.io.ByteStreams,com.google.common.cache.LoadingCache,com.google.common.base.Stopwatch,com.google.common.cache.RemovalNotification,com.google.common.util.concurrent.Uninterruptibles,com.google.common.reflect.ClassPath,com.google.common.reflect.ClassPath$ClassInfo,com.google.common.base.Throwables,com.google.common.collect.Iterators</jvmArgs>
+            <plugins combine.children="append">
+              <plugin>
+                <groupId>com.overstock.findbugs</groupId>
+                <artifactId>library-detectors</artifactId>
+                <version>1.2.0</version>
+              </plugin>
+            </plugins>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
@@ -231,6 +257,18 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>run-spotbugs</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -247,9 +285,7 @@
                 <ignoredDependency>org.apache.fluo:fluo-core:jar:${fluo.version}</ignoredDependency>
                 <ignoredDependency>org.apache.fluo:fluo-mini:jar:${fluo.version}</ignoredDependency>
                 <ignoredDependency>org.apache.fluo:fluo-recipes-kryo:jar:${project.version}</ignoredDependency>
-                <ignoredDependency>org.apache.hadoop:hadoop-client:jar:${hadoop.version}</ignoredDependency>
-                <ignoredDependency>org.apache.hadoop:hadoop-common:jar:${hadoop.version}</ignoredDependency>
-                <ignoredDependency>org.apache.hadoop:hadoop-mapreduce-client-core:jar:${hadoop.version}</ignoredDependency>
+                <ignoredDependency>org.apache.hadoop:hadoop-client-api:jar:${hadoop.version}</ignoredDependency>
               </ignoredDependencies>
             </configuration>
           </execution>
@@ -259,14 +295,25 @@
   </build>
   <profiles>
     <profile>
+      <id>add-spotbugs-excludes</id>
+      <activation>
+        <file>
+          <exists>src/main/spotbugs/exclude-filter.xml</exists>
+        </file>
+      </activation>
+      <properties>
+        <spotbugs.excludeFilterFile>src/main/spotbugs/exclude-filter.xml</spotbugs.excludeFilterFile>
+      </properties>
+    </profile>
+    <profile>
       <id>fluo-recipes-release</id>
       <!-- some properties to make the release build a bit faster -->
       <properties>
         <checkstyle.skip>true</checkstyle.skip>
-        <findbugs.skip>true</findbugs.skip>
         <modernizer.skip>true</modernizer.skip>
         <skipITs>true</skipITs>
         <skipTests>true</skipTests>
+        <spotbugs.skip>true</spotbugs.skip>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
There were some deprecated methods that were removed in Accumulo 2.0.0 that Fluo recipes was calling.  This PR avoids calling those methods and instead calls new methods introduced in Accumulo 2.0.0.