### PR TITLE
Fix #153 Update build to work on JDK11

### DIFF
--- a/modules/core/src/main/java/org/apache/fluo/recipes/core/map/CollisionFreeMap.java
+++ b/modules/core/src/main/java/org/apache/fluo/recipes/core/map/CollisionFreeMap.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.google.common.hash.Hashing;
 import org.apache.fluo.api.client.SnapshotBase;
@@ -391,7 +390,7 @@ public class CollisionFreeMap<K, V> {
     opts.save(fluoConfig.getAppConfiguration());
 
     fluoConfig.addObserver(new org.apache.fluo.api.config.ObserverSpecification(
-        CollisionFreeMapObserver.class.getName(), ImmutableMap.of("mapId", opts.mapId)));
+        CollisionFreeMapObserver.class.getName(), Map.of("mapId", opts.mapId)));
   }
 
   /**

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/common/TestGrouping.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/common/TestGrouping.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.api.config.SimpleConfiguration;
 import org.apache.fluo.api.data.Bytes;
@@ -69,8 +68,7 @@ public class TestGrouping {
     Assert.assertTrue(tableOptim.getSplits().contains(Bytes.of("m2:u:~")));
     Assert.assertTrue(tableOptim.getSplits().contains(Bytes.of("m2:d:~")));
 
-    Set<String> expectedGroups =
-        ImmutableSet.of("m1:u:", "m1:d:", "m2:u:", "m2:d:", "eq1:", "eq2:");
+    Set<String> expectedGroups = Set.of("m1:u:", "m1:d:", "m2:u:", "m2:d:", "eq1:", "eq2:");
 
     // ensure all splits group as expected
     for (Bytes split : tableOptim.getSplits()) {

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/BigUpdateIT.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/BigUpdateIT.java
@@ -20,9 +20,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import org.apache.commons.io.FileUtils;
@@ -99,7 +99,7 @@ public class BigUpdateIT {
 
       // get last values set to verify same as passed in old value
       Map<String, Long> actualOld = Maps.transformValues(
-          ttx.get().rowsString(expectedOld.keySet()).columns(ImmutableSet.of(DSCOL)).toStringMap(),
+          ttx.get().rowsString(expectedOld.keySet()).columns(Set.of(DSCOL)).toStringMap(),
           m -> m.get(DSCOL).toLong());
 
       MapDifference<String, Long> diff = Maps.difference(expectedOld, actualOld);

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/CollisionFreeMapIT.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/map/it/CollisionFreeMapIT.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.FluoFactory;
@@ -128,17 +127,17 @@ public class CollisionFreeMapIT {
   public void testGet() {
     try (FluoClient fc = FluoFactory.newClient(miniFluo.getClientConfiguration())) {
       try (Transaction tx = fc.newTransaction()) {
-        wcMap.update(tx, ImmutableMap.of("cat", 2L, "dog", 5L));
+        wcMap.update(tx, Map.of("cat", 2L, "dog", 5L));
         tx.commit();
       }
 
       try (Transaction tx = fc.newTransaction()) {
-        wcMap.update(tx, ImmutableMap.of("cat", 1L, "dog", 1L));
+        wcMap.update(tx, Map.of("cat", 1L, "dog", 1L));
         tx.commit();
       }
 
       try (Transaction tx = fc.newTransaction()) {
-        wcMap.update(tx, ImmutableMap.of("cat", 1L, "dog", 1L, "fish", 2L));
+        wcMap.update(tx, Map.of("cat", 1L, "dog", 1L, "fish", 2L));
         tx.commit();
       }
 
@@ -167,7 +166,7 @@ public class CollisionFreeMapIT {
       Assert.assertEquals(expectedCounts, getComputedWordCounts(fc));
 
       try (Transaction tx = fc.newTransaction()) {
-        wcMap.update(tx, ImmutableMap.of("cat", 1L, "dog", -7L));
+        wcMap.update(tx, Map.of("cat", 1L, "dog", -7L));
         tx.commit();
       }
 

--- a/modules/core/src/test/java/org/apache/fluo/recipes/core/types/TypeLayerTest.java
+++ b/modules/core/src/test/java/org/apache/fluo/recipes/core/types/TypeLayerTest.java
@@ -18,8 +18,8 @@ package org.apache.fluo.recipes.core.types;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.fluo.api.data.Bytes;
 import org.apache.fluo.api.data.Column;
 import org.apache.fluo.recipes.core.types.TypedSnapshotBase.Value;
@@ -38,8 +38,8 @@ public class TypeLayerTest {
 
     TypedTransactionBase ttx = tl.wrap(tt);
 
-    Map<Column, Value> results = ttx.get().row("r2")
-        .columns(ImmutableSet.of(new Column("cf2", "6"), new Column("cf2", "7")));
+    Map<Column, Value> results =
+        ttx.get().row("r2").columns(Set.of(new Column("cf2", "6"), new Column("cf2", "7")));
 
     Assert.assertNull(results.get(new Column("cf2", "6")).toInteger());
     Assert.assertEquals(0, results.get(new Column("cf2", "6")).toInteger(0));
@@ -48,8 +48,8 @@ public class TypeLayerTest {
 
     Assert.assertEquals(1, results.size());
 
-    results = ttx.get().row("r2").columns(
-        ImmutableSet.of(new Column("cf2", "6"), new Column("cf2", "7"), new Column("cf2", "8")));
+    results = ttx.get().row("r2")
+        .columns(Set.of(new Column("cf2", "6"), new Column("cf2", "7"), new Column("cf2", "8")));
 
     Assert.assertNull(results.get(new Column("cf2", "6")).toInteger());
     Assert.assertEquals(0, results.get(new Column("cf2", "6")).toInteger(0));
@@ -450,20 +450,20 @@ public class TypeLayerTest {
     Assert.assertNull(ttx.get(Bytes.of("r2"), new Column("cf2", "9")));
 
     Map<Column, Bytes> map =
-        ttx.get(Bytes.of("r2"), ImmutableSet.of(new Column("cf2", "7"), new Column("cf2", "8")));
+        ttx.get(Bytes.of("r2"), Set.of(new Column("cf2", "7"), new Column("cf2", "8")));
     Assert.assertEquals(2, map.size());
     Assert.assertEquals("12", map.get(new Column("cf2", "7")).toString());
     Assert.assertEquals("13", map.get(new Column("cf2", "8")).toString());
 
-    map = ttx.get(Bytes.of("r6"), ImmutableSet.of(new Column("cf2", "7"), new Column("cf2", "8")));
+    map = ttx.get(Bytes.of("r6"), Set.of(new Column("cf2", "7"), new Column("cf2", "8")));
     Assert.assertEquals(0, map.size());
 
     ttx.set(Bytes.of("r6"), new Column("cf2", "7"), Bytes.of("3"));
     Assert.assertEquals(MockTransactionBase.toRCVM("r6,cf2:7,3"), tt.setData);
     tt.setData.clear();
 
-    Map<Bytes, Map<Column, Bytes>> map2 = ttx.get(ImmutableSet.of(Bytes.of("r1"), Bytes.of("r2")),
-        ImmutableSet.of(new Column("cf1", "cq1"), new Column("cf2", "8")));
+    Map<Bytes, Map<Column, Bytes>> map2 = ttx.get(Set.of(Bytes.of("r1"), Bytes.of("r2")),
+        Set.of(new Column("cf1", "cq1"), new Column("cf2", "8")));
     Assert.assertEquals(MockTransactionBase.toRCVM("r1,cf1:cq1,v1", "r2,cf2:8,13"), map2);
 
     ttx.delete(Bytes.of("r6"), new Column("cf2", "7"));

--- a/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
+++ b/modules/spark/src/main/java/org/apache/fluo/recipes/spark/FluoSparkHelper.java
@@ -278,7 +278,7 @@ public class FluoSparkHelper {
      * FluoConfiguration supplied to
      * {@link FluoSparkHelper#FluoSparkHelper(FluoConfiguration, Configuration, Path)}
      *
-     * @param conn Use this connector to bulk import files into Accumulo.
+     * @param client Use this client to bulk import files into Accumulo.
      * @return this
      *
      * @since 1.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
     <findbugs.skip>true</findbugs.skip>
     <fluo.version>2.0.0-SNAPSHOT</fluo.version>
     <hadoop.version>3.1.0</hadoop.version>
-    <maven.compiler.release>8</maven.compiler.release>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <releaseProfiles>fluo-recipes-release</releaseProfiles>
     <spark.version>2.4.6</spark.version>
     <zookeeper.version>3.4.8</zookeeper.version>
@@ -226,6 +226,19 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.gaul</groupId>
+          <artifactId>modernizer-maven-plugin</artifactId>
+          <version>1.8.0</version>
+          <configuration>
+            <javaVersion>${maven.compiler.target}</javaVersion>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M3</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.1</version>
@@ -267,6 +280,11 @@
               <fluo.it.instance.clear>false</fluo.it.instance.clear>
             </systemPropertyVariables>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.1.2</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
* Update -release target to 11, to match JDK 11 source files
* Update some plugins that need to be newer to run on JDK 11
* Fix modernizer warnings by using Java builtins instead of Guava
  classes
* Fix incorrect param name in javadoc